### PR TITLE
fix(pay): 修复前台支付方式显示错误

### DIFF
--- a/src/__tests__/app/api/user-route.test.ts
+++ b/src/__tests__/app/api/user-route.test.ts
@@ -5,7 +5,7 @@ const mockGetCurrentUserByToken = vi.fn();
 const mockGetUser = vi.fn();
 const mockGetSystemConfig = vi.fn();
 const mockQueryMethodLimits = vi.fn();
-const mockGetSupportedTypes = vi.fn();
+const mockGetEnabledPaymentTypes = vi.fn();
 
 vi.mock('@/lib/sub2api/client', () => ({
   getCurrentUserByToken: (...args: unknown[]) => mockGetCurrentUserByToken(...args),
@@ -30,7 +30,7 @@ vi.mock('@/lib/order/limits', () => ({
 vi.mock('@/lib/payment', () => ({
   initPaymentProviders: vi.fn(),
   paymentRegistry: {
-    getSupportedTypes: (...args: unknown[]) => mockGetSupportedTypes(...args),
+    getSupportedTypes: vi.fn(),
   },
 }));
 
@@ -50,16 +50,8 @@ vi.mock('@/lib/system-config', () => ({
 }));
 
 vi.mock('@/lib/payment/resolve-enabled-types', () => ({
-  resolveEnabledPaymentTypes: (supported: string[], configured: string | undefined) => {
-    if (!configured || configured.trim() === '') return supported;
-    const set = new Set(
-      configured
-        .split(',')
-        .map((s: string) => s.trim())
-        .filter(Boolean),
-    );
-    return supported.filter((t: string) => set.has(t));
-  },
+  getEnabledPaymentTypes: (...args: unknown[]) => mockGetEnabledPaymentTypes(...args),
+  resolveEnabledPaymentTypes: vi.fn(),
 }));
 
 import { GET } from '@/app/api/user/route';
@@ -74,7 +66,7 @@ describe('GET /api/user', () => {
     vi.clearAllMocks();
     mockGetCurrentUserByToken.mockResolvedValue({ id: 1, status: 'active' });
     mockGetUser.mockResolvedValue({ id: 1, status: 'active' });
-    mockGetSupportedTypes.mockReturnValue(['alipay', 'wxpay', 'stripe']);
+    mockGetEnabledPaymentTypes.mockResolvedValue(['alipay', 'wxpay', 'stripe']);
     mockQueryMethodLimits.mockResolvedValue({
       alipay: { maxDailyAmount: 1000 },
       wxpay: { maxDailyAmount: 1000 },
@@ -131,12 +123,8 @@ describe('GET /api/user', () => {
 
   // ── Payment type filtering tests ──
 
-  it('filters enabled payment types by ENABLED_PAYMENT_TYPES config', async () => {
-    mockGetSystemConfig.mockImplementation(async (key: string) => {
-      if (key === 'ENABLED_PAYMENT_TYPES') return 'alipay,wxpay';
-      if (key === 'BALANCE_PAYMENT_DISABLED') return 'false';
-      return undefined;
-    });
+  it('returns enabled payment types from shared payment config resolver', async () => {
+    mockGetEnabledPaymentTypes.mockResolvedValue(['alipay', 'wxpay']);
 
     const response = await GET(createRequest());
     const data = await response.json();
@@ -146,22 +134,17 @@ describe('GET /api/user', () => {
     expect(mockQueryMethodLimits).toHaveBeenCalledWith(['alipay', 'wxpay']);
   });
 
-  it('falls back to supported payment types when ENABLED_PAYMENT_TYPES is empty', async () => {
-    mockGetSystemConfig.mockImplementation(async (key: string) => {
-      if (key === 'ENABLED_PAYMENT_TYPES') return '   ';
-      if (key === 'BALANCE_PAYMENT_DISABLED') return 'false';
-      return undefined;
-    });
-
+  it('supports instance-constrained enabled payment types', async () => {
+    mockGetEnabledPaymentTypes.mockResolvedValue(['wxpay']);
     const response = await GET(createRequest());
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.config.enabledPaymentTypes).toEqual(['alipay', 'wxpay', 'stripe']);
-    expect(mockQueryMethodLimits).toHaveBeenCalledWith(['alipay', 'wxpay', 'stripe']);
+    expect(data.config.enabledPaymentTypes).toEqual(['wxpay']);
+    expect(mockQueryMethodLimits).toHaveBeenCalledWith(['wxpay']);
   });
 
-  it('falls back to supported payment types when ENABLED_PAYMENT_TYPES is undefined', async () => {
+  it('falls back to all enabled payment types when resolver returns the full set', async () => {
     const response = await GET(createRequest());
     const data = await response.json();
 
@@ -204,7 +187,7 @@ describe('GET /api/user', () => {
 
   it('generates sublabel overrides when multiple types share same label', async () => {
     // alipay and alipay_direct both have channel "alipay" in the mock
-    mockGetSupportedTypes.mockReturnValue(['alipay', 'alipay_direct', 'stripe']);
+    mockGetEnabledPaymentTypes.mockResolvedValue(['alipay', 'alipay_direct', 'stripe']);
     mockQueryMethodLimits.mockResolvedValue({});
 
     const response = await GET(createRequest());
@@ -219,7 +202,7 @@ describe('GET /api/user', () => {
 
   it('returns null sublabelOverrides when no conflicts', async () => {
     // Each type has a unique channel label
-    mockGetSupportedTypes.mockReturnValue(['stripe']);
+    mockGetEnabledPaymentTypes.mockResolvedValue(['stripe']);
     mockQueryMethodLimits.mockResolvedValue({});
 
     const response = await GET(createRequest());

--- a/src/__tests__/lib/payment/resolve-enabled-types.test.ts
+++ b/src/__tests__/lib/payment/resolve-enabled-types.test.ts
@@ -1,16 +1,43 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetSystemConfig = vi.fn();
+const mockFindMany = vi.fn();
+const mockGetSupportedTypes = vi.fn();
+const mockGetProviderKey = vi.fn();
 
 // Mock transitive dependencies to prevent env validation
 vi.mock('@/lib/system-config', () => ({
-  getSystemConfig: vi.fn(),
+  getSystemConfig: (...args: unknown[]) => mockGetSystemConfig(...args),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    paymentProviderInstance: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+    },
+  },
 }));
 
 vi.mock('@/lib/payment', () => ({
   initPaymentProviders: vi.fn(),
-  paymentRegistry: { getSupportedTypes: () => [] },
+  paymentRegistry: {
+    getSupportedTypes: (...args: unknown[]) => mockGetSupportedTypes(...args),
+    getProviderKey: (...args: unknown[]) => mockGetProviderKey(...args),
+  },
 }));
 
-import { resolveEnabledPaymentTypes } from '@/lib/payment/resolve-enabled-types';
+import {
+  getEnabledPaymentTypes,
+  resolveEnabledPaymentTypes,
+} from '@/lib/payment/resolve-enabled-types';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSystemConfig.mockResolvedValue(undefined);
+  mockFindMany.mockResolvedValue([]);
+  mockGetSupportedTypes.mockReturnValue([]);
+  mockGetProviderKey.mockReturnValue(undefined);
+});
 
 describe('resolveEnabledPaymentTypes', () => {
   const allTypes = ['alipay', 'wxpay', 'stripe'];
@@ -49,5 +76,42 @@ describe('resolveEnabledPaymentTypes', () => {
 
   it('handles single type', () => {
     expect(resolveEnabledPaymentTypes(allTypes, 'wxpay')).toEqual(['wxpay']);
+  });
+});
+
+describe('getEnabledPaymentTypes', () => {
+  it('filters configured payment types by enabled provider instances', async () => {
+    mockGetSupportedTypes.mockReturnValue(['alipay', 'wxpay', 'stripe']);
+    mockGetProviderKey.mockImplementation((type: string) => {
+      if (type === 'alipay' || type === 'wxpay') return 'easypay';
+      if (type === 'stripe') return 'stripe';
+      return undefined;
+    });
+    mockGetSystemConfig.mockResolvedValue('alipay,wxpay');
+    mockFindMany.mockResolvedValue([{ providerKey: 'easypay', supportedTypes: 'wxpay' }]);
+
+    await expect(getEnabledPaymentTypes()).resolves.toEqual(['wxpay']);
+  });
+
+  it('treats empty instance supportedTypes as wildcard', async () => {
+    mockGetSupportedTypes.mockReturnValue(['alipay', 'wxpay']);
+    mockGetProviderKey.mockReturnValue('easypay');
+    mockGetSystemConfig.mockResolvedValue('alipay,wxpay');
+    mockFindMany.mockResolvedValue([{ providerKey: 'easypay', supportedTypes: '' }]);
+
+    await expect(getEnabledPaymentTypes()).resolves.toEqual(['alipay', 'wxpay']);
+  });
+
+  it('preserves payment types for providers without enabled instances', async () => {
+    mockGetSupportedTypes.mockReturnValue(['alipay', 'wxpay', 'stripe']);
+    mockGetProviderKey.mockImplementation((type: string) => {
+      if (type === 'alipay' || type === 'wxpay') return 'easypay';
+      if (type === 'stripe') return 'stripe';
+      return undefined;
+    });
+    mockGetSystemConfig.mockResolvedValue('stripe');
+    mockFindMany.mockResolvedValue([{ providerKey: 'easypay', supportedTypes: 'wxpay' }]);
+
+    await expect(getEnabledPaymentTypes()).resolves.toEqual(['stripe']);
   });
 });

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -2,11 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentUserByToken } from '@/lib/sub2api/client';
 import { getEnv } from '@/lib/config';
 import { queryMethodLimits } from '@/lib/order/limits';
-import { initPaymentProviders, paymentRegistry } from '@/lib/payment';
 import { getPaymentDisplayInfo } from '@/lib/pay-utils';
 import { resolveLocale } from '@/lib/locale';
 import { getSystemConfig } from '@/lib/system-config';
-import { resolveEnabledPaymentTypes } from '@/lib/payment/resolve-enabled-types';
+import { getEnabledPaymentTypes } from '@/lib/payment/resolve-enabled-types';
 
 export async function GET(request: NextRequest) {
   const locale = resolveLocale(request.nextUrl.searchParams.get('lang'));
@@ -40,42 +39,26 @@ export async function GET(request: NextRequest) {
     }
 
     const env = getEnv();
-    initPaymentProviders();
-    const supportedTypes = paymentRegistry.getSupportedTypes();
-
-    // getUser 与 config 查询并行；config 完成后立即启动 queryMethodLimits
+    const enabledTypesPromise = getEnabledPaymentTypes();
     const configPromise = Promise.all([
-      getSystemConfig('ENABLED_PAYMENT_TYPES'),
       getSystemConfig('BALANCE_PAYMENT_DISABLED'),
       getSystemConfig('MAX_PENDING_ORDERS'),
       getSystemConfig('RECHARGE_MIN_AMOUNT'),
       getSystemConfig('RECHARGE_MAX_AMOUNT'),
       getSystemConfig('DAILY_RECHARGE_LIMIT'),
     ]).then(
-      async ([
-        configuredPaymentTypesRaw,
-        balanceDisabledVal,
-        maxPendingVal,
-        minAmountVal,
-        maxAmountVal,
-        dailyLimitVal,
-      ]) => {
-        const enabledTypes = resolveEnabledPaymentTypes(supportedTypes, configuredPaymentTypesRaw);
-        const methodLimits = await queryMethodLimits(enabledTypes);
-        return {
-          enabledTypes,
-          methodLimits,
-          balanceDisabled: balanceDisabledVal === 'true',
-          maxPendingOrders: maxPendingVal ? parseInt(maxPendingVal, 10) || 3 : 3,
-          minAmount: minAmountVal ? parseFloat(minAmountVal) || env.MIN_RECHARGE_AMOUNT : env.MIN_RECHARGE_AMOUNT,
-          maxAmount: maxAmountVal ? parseFloat(maxAmountVal) || env.MAX_RECHARGE_AMOUNT : env.MAX_RECHARGE_AMOUNT,
-          maxDailyAmount: dailyLimitVal ? parseFloat(dailyLimitVal) : env.MAX_DAILY_RECHARGE_AMOUNT,
-        };
-      },
+      ([balanceDisabledVal, maxPendingVal, minAmountVal, maxAmountVal, dailyLimitVal]) => ({
+        balanceDisabled: balanceDisabledVal === 'true',
+        maxPendingOrders: maxPendingVal ? parseInt(maxPendingVal, 10) || 3 : 3,
+        minAmount: minAmountVal ? parseFloat(minAmountVal) || env.MIN_RECHARGE_AMOUNT : env.MIN_RECHARGE_AMOUNT,
+        maxAmount: maxAmountVal ? parseFloat(maxAmountVal) || env.MAX_RECHARGE_AMOUNT : env.MAX_RECHARGE_AMOUNT,
+        maxDailyAmount: dailyLimitVal ? parseFloat(dailyLimitVal) : env.MAX_DAILY_RECHARGE_AMOUNT,
+      }),
     );
 
-    const { enabledTypes, methodLimits, balanceDisabled, maxPendingOrders, minAmount, maxAmount, maxDailyAmount } =
-      await configPromise;
+    const [enabledTypes, { balanceDisabled, maxPendingOrders, minAmount, maxAmount, maxDailyAmount }] =
+      await Promise.all([enabledTypesPromise, configPromise]);
+    const methodLimits = await queryMethodLimits(enabledTypes);
 
     // 收集 sublabel 覆盖
     const sublabelOverrides: Record<string, string> = {};

--- a/src/lib/payment/resolve-enabled-types.ts
+++ b/src/lib/payment/resolve-enabled-types.ts
@@ -1,3 +1,4 @@
+import { prisma } from '@/lib/db';
 import { getSystemConfig } from '@/lib/system-config';
 import { initPaymentProviders, paymentRegistry } from '@/lib/payment';
 
@@ -19,6 +20,49 @@ export function resolveEnabledPaymentTypes(supportedTypes: string[], configuredT
   return supportedTypes.filter((type) => configuredTypeSet.has(type));
 }
 
+interface EnabledProviderInstance {
+  providerKey: string;
+  supportedTypes: string | null;
+}
+
+function parseSupportedTypes(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((type) => type.trim())
+    .filter(Boolean);
+}
+
+export function filterEnabledPaymentTypesByInstances(
+  enabledTypes: string[],
+  enabledInstances: EnabledProviderInstance[],
+): string[] {
+  if (enabledTypes.length === 0 || enabledInstances.length === 0) return enabledTypes;
+
+  const instancesByProvider = new Map<string, EnabledProviderInstance[]>();
+  for (const instance of enabledInstances) {
+    const instances = instancesByProvider.get(instance.providerKey) || [];
+    instances.push(instance);
+    instancesByProvider.set(instance.providerKey, instances);
+  }
+
+  return enabledTypes.filter((type) => {
+    const providerKey = paymentRegistry.getProviderKey(type);
+    if (!providerKey) return false;
+
+    const providerInstances = instancesByProvider.get(providerKey);
+    if (!providerInstances || providerInstances.length === 0) {
+      // No DB instances for this provider: keep legacy env-based fallback behavior.
+      return true;
+    }
+
+    return providerInstances.some((instance) => {
+      const supportedTypes = parseSupportedTypes(instance.supportedTypes);
+      return supportedTypes.length === 0 || supportedTypes.includes(type);
+    });
+  });
+}
+
 /**
  * 获取当前启用的支付类型（结合 registry 支持类型 + 数据库 ENABLED_PAYMENT_TYPES 配置）。
  */
@@ -26,5 +70,13 @@ export async function getEnabledPaymentTypes(): Promise<string[]> {
   initPaymentProviders();
   const supportedTypes = paymentRegistry.getSupportedTypes();
   const configuredTypes = await getSystemConfig('ENABLED_PAYMENT_TYPES');
-  return resolveEnabledPaymentTypes(supportedTypes, configuredTypes);
+  const enabledTypes = resolveEnabledPaymentTypes(supportedTypes, configuredTypes);
+  if (enabledTypes.length === 0) return enabledTypes;
+
+  const enabledInstances = await prisma.paymentProviderInstance.findMany({
+    where: { enabled: true },
+    select: { providerKey: true, supportedTypes: true },
+  });
+
+  return filterEnabledPaymentTypesByInstances(enabledTypes, enabledInstances);
 }


### PR DESCRIPTION
## 说明

修复前台支付方式没有按已启用实例的 `supportedTypes` 过滤的问题。

例如后台只配置了微信实例时，前台仍可能显示支付宝。  
本次调整后，前台和下单校验都会按实例实际支持的支付方式收敛。

## 测试

- `src/__tests__/lib/payment/resolve-enabled-types.test.ts`
- `src/__tests__/app/api/user-route.test.ts`
- `npm run typecheck`